### PR TITLE
Fix description of pvep using semi-empirical method for geometry optimization

### DIFF
--- a/semi-empirical/parameterised-packages/excitation-energy-pm6-gamess-us.json
+++ b/semi-empirical/parameterised-packages/excitation-energy-pm6-gamess-us.json
@@ -8,7 +8,7 @@
       ],
       "maintainer": "https://github.com/michael-johnston",
       "license": "Apache 2.0",
-      "description": "Uses semi the PM6 semi empirical method to perform geometry optimization and calculate the band-gap and related properties. This is followed by a TD-DFT calculation to calculate the excitation energy. The calculation is performed with GAMESS-US. Functional/Basis-Set for both calculations are PM6 method: B3LYP/KTZVP + D3. Number of states for TD-DFT is 10.",
+      "description": "Uses the PM6 semi empirical method to perform geometry optimization and calculate the band-gap and related properties. This is followed by a TD-DFT calculation to calculate the excitation energy. Both calculations are performed with GAMESS-US. Functional/Basis-Set for the TD-DFT calculation is B3LYP/KTZVP + D3. Number of states for TD-DFT is 10.",
       "keywords": [
         "smiles",
         "computational chemistry",


### PR DESCRIPTION
Fix description of PVEP

## Context

The current description of the PVEP defined in excitation-energy-pm6-gamess-us.json - which is the source of https://registry.st4sd.res.ibm.com/registry-ui/experiment/excitation-energy-pm6-gamess-us -  contains an incorrect statement "Functional/Basis-Set for both calculations are PM6 method: B3LYP/KTZVP + D3". 

PM6 is a semi-empirical method used only in the first geometry-optimization calculation. B3LYP/KTZVP + D3 is the DFT functional/basis-set used only in the second TDDFT calculation.


## Change list

Write a few bullet points of the changes contained in this PR:

- A change to the description field of [semi-empirical/parameterised-packages/excitation-energy-pm6-gamess-us.json](https://github.com/st4sd/excitation-energy-gamess/compare/main...michael-johnston-patch-1?quick_pull=1#diff-b6d89562514dfa171617da02b8d4c9bb9a630a97c7a6ee77f8feab5f9498aabe)


## Checklist

Ensure your PR meets the following requirements:

- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
